### PR TITLE
Fix issue when MPI compiler has compile flags

### DIFF
--- a/src/pebbl/CMakeLists.txt
+++ b/src/pebbl/CMakeLists.txt
@@ -15,10 +15,10 @@ add_library(pebbl ${bb_srcs} ${bb_headers} ${comm_srcs} ${comm_headers} ${misc_s
             ${pebbl_srcs} ${pebbl_headers} ${sched_srcs} ${sched_headers} ${utilib_srcs} ${utilib_headers})
 if(enable_mpi)
   if(MPI_CXX_COMPILE_FLAGS)
-    target_compile_options(pebbl ${MPI_CXX_COMPILE_FLAGS})
+    target_compile_options(pebbl PUBLIC ${MPI_CXX_COMPILE_FLAGS})
   endif()
   set_target_properties(pebbl PROPERTIES LINK_FLAGS ${MPI_CXX_LINK_FLAGS})
-  target_link_libraries(pebbl ${MPI_CXX_LIBRARIES})
+  target_link_libraries(pebbl PUBLIC ${MPI_CXX_LIBRARIES})
 endif()
 
 install(TARGETS pebbl EXPORT PEBBL DESTINATION ${lib_install_dir})


### PR DESCRIPTION
Fixes issue #4

I was able to configure and compile with cmake 3.10.3 and cmake 3.5.2. The cmake 3.10 had compile options for MPI where cmake 3.5 did not. Both used the same gcc 4.9.3 and openmpi 1.10.1. The configure, build and tests all worked. In addition serial configure, build, and tests were run for both cmake 3.10.3 and cmake 3.5.3.