### PR TITLE
Replace deprecated MPI calls and remove global macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 *.exe
 *.out
 *.app
+
+design-diagrams/*

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,3 @@
 *.exe
 *.out
 *.app
-
-design-diagrams/*

--- a/packages/utilib/src/exec/memmon.c
+++ b/packages/utilib/src/exec/memmon.c
@@ -103,7 +103,7 @@ getmem(pid_t child) {
     return -1;
 
 /* Not all processes have a VmSize, e.g. Zombies */
-  while (fscanf(fd, "%255s %ld %*[^\n]", item, &tmp) != EOF) {
+  while (fscanf(fd, "%255s %ld %*[^\n]", item, &tmp) != -1) {
     if (strcmp(item,"VmSize:") == 0) {
 
        mem = tmp;

--- a/packages/utilib/test/studies/splay.cpp
+++ b/packages/utilib/test/studies/splay.cpp
@@ -44,10 +44,10 @@ public:
   T val;
 
   int write(ostream& os) const
-	{os << val; return 0;}
+	{os << val; return OK;}
 
   int read(istream& is)
-	{is >> val; return 0;}
+	{is >> val; return OK;}
 
   A<T>& operator=(A<T>& tmp)
 	{val = tmp.val; return *this;}
@@ -299,5 +299,5 @@ do_stest<int>("Testing int simpleST",cout);
 do_test<CharString>("Testing char* HT with default function",cout);
 }
 
-return 0;
+return OK;
 }

--- a/packages/utilib/test/studies/splay.cpp
+++ b/packages/utilib/test/studies/splay.cpp
@@ -44,10 +44,10 @@ public:
   T val;
 
   int write(ostream& os) const
-	{os << val; return OK;}
+	{os << val; return 0;}
 
   int read(istream& is)
-	{is >> val; return OK;}
+	{is >> val; return 0;}
 
   A<T>& operator=(A<T>& tmp)
 	{val = tmp.val; return *this;}
@@ -299,5 +299,5 @@ do_stest<int>("Testing int simpleST",cout);
 do_test<CharString>("Testing char* HT with default function",cout);
 }
 
-return OK;
+return 0;
 }

--- a/packages/utilib/test/studies/triang.cpp
+++ b/packages/utilib/test/studies/triang.cpp
@@ -85,5 +85,5 @@ ucout << "Test Expectation-Balanced Triangular" << std::endl;
 trv.truncation(EXPECTATION_BALANCED_TRIANGULAR);
 test_triang(&trv,-0.5,1.0,vec,10000);
 ucout << vec << std::endl;
-return 0;
+return OK;
 }

--- a/packages/utilib/test/studies/triang.cpp
+++ b/packages/utilib/test/studies/triang.cpp
@@ -85,5 +85,5 @@ ucout << "Test Expectation-Balanced Triangular" << std::endl;
 trv.truncation(EXPECTATION_BALANCED_TRIANGULAR);
 test_triang(&trv,-0.5,1.0,vec,10000);
 ucout << vec << std::endl;
-return OK;
+return 0;
 }

--- a/src/pebbl/bb/branching.cpp
+++ b/src/pebbl/bb/branching.cpp
@@ -1447,16 +1447,16 @@ void branching::statusPrint(int&        lastPrint,
 	  << ", last=" << lastPrint << (l.mismatch() ? ", mismatch" : "")
 	  << ".\n");
 
-  int needPrint = FALSE;
+  int needPrint = false;
 
   if ((statusPrintCount > 0) &&
       (l.boundedSPs >= lastPrint + statusPrintCount))
-    needPrint = TRUE;
+    needPrint = true;
 
   double now = WallClockSeconds();
   if ((statusPrintSeconds > 0) &&
       (now >= lastPrintTime + statusPrintSeconds))
-    needPrint = TRUE;
+    needPrint = true;
 
   if (needPrint)
     {
@@ -1559,7 +1559,7 @@ void branching::statusLine(loadObject& l, const char* tag)
 int branching::serialNeedEarlyOutput()
 {
   if (WallClockSeconds() < nextOutputTime)
-    return FALSE;
+    return false;
   return sense*(incumbentValue - lastSolValOutput) < 0;
 }
 

--- a/src/pebbl/comm/MessageID.cpp
+++ b/src/pebbl/comm/MessageID.cpp
@@ -38,7 +38,7 @@ int MessageID::check_id()
 {
 int tmp;
 int flag;
-MPI_Attr_get(uMPI::comm, MPI_TAG_UB, (void*)&tmp, &flag);
+MPI_Comm_get_attr(uMPI::comm, MPI_TAG_UB, (void*)&tmp, &flag);
 assert(flag == 1);
 
 return (next_id < tmp);

--- a/src/pebbl/comm/coTree.cpp
+++ b/src/pebbl/comm/coTree.cpp
@@ -66,13 +66,13 @@ int coTree::run()
 {
   int canContinue;
 
-#define jumpState(newState) { state = newState; canContinue = TRUE; break; }
+#define jumpState(newState) { state = newState; canContinue = true; break; }
 
   do 
 
     {
 
-      canContinue = FALSE;
+      canContinue = false;
 
       switch(state) {
 

--- a/src/pebbl/comm/mpiComm.cpp
+++ b/src/pebbl/comm/mpiComm.cpp
@@ -58,9 +58,9 @@ comm(comm_)
   // fall back on ioProc=0 default.
   int flag, result;
   int* mpiIOP;
-  errorCode = MPI_Attr_get(MPI_COMM_WORLD,MPI_IO,&mpiIOP,&flag);
+  errorCode = MPI_Comm_get_attr(MPI_COMM_WORLD,MPI_IO,&mpiIOP,&flag);
   if (errorCode || !flag)
-     ucerr << "MPI_Attr_get(MPI_IO) failed, code " << errorCode << endl;
+     ucerr << "MPI_Comm_get_attr(MPI_IO) failed, code " << errorCode << endl;
   MPI_Comm_compare(comm, MPI_COMM_WORLD, &result);
   if (result==MPI_IDENT || result==MPI_CONGRUENT) // no mapping of MPI_IO reqd.
     ioProc = *mpiIOP;

--- a/src/pebbl/example/logAnalyze.cpp
+++ b/src/pebbl/example/logAnalyze.cpp
@@ -69,7 +69,7 @@ int printTreeDepth=5;
 //  Globals (ugh).  I never said it was elegant.
 
 int errorCount = 0;
-int fathomRead = FALSE;
+int fathomRead = false;
 double sol     = 0;
 double sense   = 1;
 double relTol  = 1e-7;
@@ -254,10 +254,10 @@ int canFathom(double bound)
 {
   double absGap = (sol - bound)*sense;
   if (absGap < absTol)
-    return TRUE;
+    return true;
   double denom = max(fabs(bound),fabs(sol));
   if (denom == 0)
-    return TRUE;
+    return true;
   else return absGap/denom <= relTol;
 }
 
@@ -344,7 +344,7 @@ void readLog::execute(int argc,char** argv)
 	  if (!strcmp(verb,"fathoming"))
 	    {
 	      lineStream >> sol >> sense >> relTol >> absTol;
-	      fathomRead = TRUE;
+	      fathomRead = true;
 	    }
 	  else
 	    {

--- a/src/pebbl/example/serialKnapsack.cpp
+++ b/src/pebbl/example/serialKnapsack.cpp
@@ -80,7 +80,7 @@ bool binaryKnapsack::setupProblem(int& argc,char**& argv)
 
   // Read in all the items and throw them on a heap
 
-  int allInteger = TRUE;
+  int allInteger = true;
 
   GenericHeap<knapsackItem> heap;
 
@@ -110,7 +110,7 @@ bool binaryKnapsack::setupProblem(int& argc,char**& argv)
 	{
 	  heap.add(*(new knapsackItem(w,v,tempName)));
 	  if (v != floor(v))
-	    allInteger = FALSE;
+	    allInteger = false;
 	  numItems++;
 	  sumOfAllValues += v;
 	}
@@ -576,7 +576,7 @@ void binKnapSolution::squeezeInGreedy()
       binKnapSolution temp(global);  // Make a temporary solution.
       --(global->solSerialCounter);  // but don't use up a serial number
       temp.reset(initialSequence);
-      int changesMade = FALSE;
+      int changesMade = false;
       itemListCursor alreadyIn(genItems,&genItem);
 
       // Scan items that we may have skipped before.
@@ -594,7 +594,7 @@ void binKnapSolution::squeezeInGreedy()
 	    {
 	      temp.addItem(i);
 	      left -= itemWeight(i);
-	      changesMade = TRUE;
+	      changesMade = true;
 	    }
 	}
 

--- a/src/pebbl/example/serialMonomial.cpp
+++ b/src/pebbl/example/serialMonomial.cpp
@@ -160,7 +160,7 @@ namespace pebblMonom {
 				   int*          blocklen,
 				   int           j)
   {
-    MPI_Address(address,&(disp[j]));
+    MPI_Get_address(address,&(disp[j]));
     disp[j] -= base;
     type[j] = MPI_DOUBLE;
     blocklen[j] = 1;
@@ -177,7 +177,7 @@ namespace pebblMonom {
     MPI_Aint     base;
     branchChoice example;
 
-    MPI_Address(&example,&base);
+    MPI_Get_address(&example,&base);
 
     int j = 0;
     for (int i=0; i<3; i++)
@@ -193,7 +193,7 @@ namespace pebblMonom {
       }
     setupMPIDatum(&(example.branchVar),MPI_INT,
 		  type,base,disp,blocklen,j++);
-    MPI_Type_struct(j,blocklen,disp,type,&mpiType);
+    MPI_Type_create_struct(j,blocklen,disp,type,&mpiType);
     MPI_Type_commit(&mpiType);
     MPI_Op_create(branchChoiceCombiner,true,&mpiCombiner);
   }

--- a/src/pebbl/pbb/pbOutput.cpp
+++ b/src/pebbl/pbb/pbOutput.cpp
@@ -182,7 +182,7 @@ void parallelBranching::solutionToFile()
       if (iAmFirstHub() &&
 	  (earlyOutputMinutes > 0) && 
 	  (lastSolValOutput == incumbentValue))
-	flag = TRUE;
+	flag = true;
       uMPI::broadcast((void*) &flag,1,MPI_INT,firstHub());
       solOutputMessages += (uMPI::rank > 0);
 

--- a/src/pebbl/sched/Scheduler.cpp
+++ b/src/pebbl/sched/Scheduler.cpp
@@ -297,7 +297,7 @@ while (!termination_flag) {
   }
 
 total_time = getTime() - ttime;
-return OK;
+return 0;
 }
 
 

--- a/src/pebbl/sched/Scheduler.cpp
+++ b/src/pebbl/sched/Scheduler.cpp
@@ -30,7 +30,7 @@ namespace pebbl {
 // Scheduler static data
 //
 //
-int Scheduler::termination_flag=FALSE;
+int Scheduler::termination_flag=false;
 
 
 //
@@ -205,7 +205,7 @@ void Scheduler::dump()
 int Scheduler::execute()
 {
 size_type group_ndx=0;
-termination_flag = FALSE;
+termination_flag = false;
 double ttime=getTime();
 
 
@@ -219,7 +219,7 @@ DEBUGPR(1,dump());
 // Main loop
 //
 while (!termination_flag) {
-  state_changed=FALSE;
+  state_changed=false;
   //
   // Time this iteration began
   //
@@ -239,7 +239,7 @@ while (!termination_flag) {
        if (thread->ready())
           threadGroup[thread->group()]->unblock(thread,getTime());
        insert(ThreadObj::RunOK,thread);		// Move to an interrupt queue
-       state_changed=TRUE;
+       state_changed=true;
        }
     else
        ndx = algBlockedList.next(ndx);
@@ -439,7 +439,7 @@ void Scheduler::check_waiting_threads()
           if (thread->ready())
 	    threadGroup[thread->group()]->unblock(thread,getTime());
 	  insert(ThreadObj::RunOK,thread);
-          state_changed=TRUE;
+          state_changed=true;
       }
     }
   }
@@ -469,7 +469,7 @@ void Scheduler::check_waiting_threads()
           if (thread->ready())
 	    threadGroup[thread->group()]->unblock(thread,getTime());
 	  insert(ThreadObj::RunOK,thread);
-          state_changed=TRUE;
+          state_changed=true;
       }
     }
   }

--- a/src/pebbl/utilib-old/Basic3DArray.h
+++ b/src/pebbl/utilib-old/Basic3DArray.h
@@ -404,7 +404,7 @@ int Basic3DArray<T>::resize(const size_type nrows, const size_type ncols, const 
 // Maybe we get lucky.
 //
 if ((ncols == a->Ncols) && (nrows == a->Nrows) && (ndeep == a->Ndeep))
-   return OK;
+   return 0;
 
 //
 // Need to completely replace old data.
@@ -446,7 +446,7 @@ if ((ncols != a->Ncols) && (nrows != a->Nrows) && (ndeep != a->Ndeep)) {
    a->Nrows = nrows;
    a->Ncols = ncols;
    a->Ndeep = ndeep;
-   return OK;
+   return 0;
    }
 
 //
@@ -506,7 +506,7 @@ if (ncols != a->Ncols) {
    a->Ncols = ncols;
    }
 
-return OK;
+return 0;
 }
 
 

--- a/src/pebbl/utilib-old/MNormal.h
+++ b/src/pebbl/utilib-old/MNormal.h
@@ -185,7 +185,7 @@ inline void MNormal::operator()(DoubleVector& new_result)
 if (!pGenerator)
    EXCEPTION_MNGR(runtime_error, "MNormal::operator() : Attempting to use a NULL generator.");
 
-if (pd_flag == ERR)
+if (pd_flag == PEBBL_ERR)
    EXCEPTION_MNGR(runtime_error, "MNormal::operator() : Attempting to use a bad correlation matrix.");
 
 if (results.size() == 0)

--- a/src/pebbl/utilib-old/MixedIntVars.cpp
+++ b/src/pebbl/utilib-old/MixedIntVars.cpp
@@ -30,7 +30,7 @@ int cast_real_to_miv(const Any& from, Any& to)
    ans.Real() << from.expose<NumArray<double> >();
    ans.Integer().resize(0);
    ans.Binary().resize(0);
-   return OK;
+   return 0;
 }
 
 int cast_int_to_miv(const Any& from, Any& to)
@@ -39,7 +39,7 @@ int cast_int_to_miv(const Any& from, Any& to)
    ans.Real().resize(0);
    ans.Integer() << from.expose<NumArray<int> >();
    ans.Binary().resize(0);
-   return OK;
+   return 0;
 }
 
 } // namespace utilib::(local)

--- a/src/pebbl/utilib-old/OStreamTee.h
+++ b/src/pebbl/utilib-old/OStreamTee.h
@@ -37,13 +37,13 @@ private:
 
       virtual int overflow(int c)
       {
-         if (c == EOF)
-            return !EOF;
+         if (c == -1)
+            return !-1;
          else
          {
             int const ans1 = buffer1->sputc(c);
             int const ans2 = buffer2->sputc(c);
-            return ans1 == EOF || ans2 == EOF ? EOF : c;
+            return ans1 == -1 || ans2 == -1 ? -1 : c;
          }
       }
 

--- a/src/pebbl/utilib-old/SparseMatrix.h
+++ b/src/pebbl/utilib-old/SparseMatrix.h
@@ -189,7 +189,7 @@ private:
    static int convert_cast(const Any& from, Any& to)
    {
       to.set<TO>().convert(from.template expose<FROM>());
-      return OK;
+      return 0;
    }
 
    //static int cast_to_rm_from_dense(const Any& from, Any& to);
@@ -635,7 +635,7 @@ for (int i=0; i<nrows; i++) {
     ostr << operator()(i,j) << " ";
   ostr << std::endl;
   }
-return OK;
+return 0;
 }
 
 
@@ -1184,7 +1184,7 @@ int cast_to_rm_from_dense(const Any& from_, Any& to_)
       = to_.set<utilib::RMSparseMatrix<T> > ();
 
    if (from.size() == 0)
-      return OK;
+      return 0;
 
    T zero = T();
    size_t nr = from.size();
@@ -1221,7 +1221,7 @@ int cast_to_rm_from_dense(const Any& from_, Any& to_)
             matval[ctr++] = from[i][j];
          }
    }
-   return OK;
+   return 0;
 }
 
 
@@ -1258,7 +1258,7 @@ int cast_from_rm_to_dense(const Any& from_, Any& to_)
       }
    }
 
-   return OK;
+   return 0;
 }
 
 } // namespace utilib::(local)
@@ -1308,7 +1308,7 @@ int SparseMatrix<T>::cast_to_cm_from_BasicArrayArray(const Any& _from, Any& to)
       //std::cerr << "matval " << matval << std::endl;
    }
 
-   return OK;
+   return 0;
 }
 
 template<typename T>
@@ -1346,7 +1346,7 @@ int SparseMatrix<T>::cast_from_cm_to_BasicArrayArray(const Any& _from, Any& to)
       }
    }
 
-   return OK;
+   return 0;
 }
 
 

--- a/src/pebbl/utilib-old/cholesky.cpp
+++ b/src/pebbl/utilib-old/cholesky.cpp
@@ -53,7 +53,7 @@ if (rcond != NULL) {
 else
    dpofa_(&(G[0][0]), &n, &n, &info);
 
-if (info != 0) return ERR;
+if (info != 0) return PEBBL_ERR;
 return OK;
 }
 

--- a/src/pebbl/utilib-old/cholesky.cpp
+++ b/src/pebbl/utilib-old/cholesky.cpp
@@ -54,7 +54,7 @@ else
    dpofa_(&(G[0][0]), &n, &n, &info);
 
 if (info != 0) return ERR;
-return OK;
+return 0;
 }
 
 

--- a/src/pebbl/utilib-old/median.cpp
+++ b/src/pebbl/utilib-old/median.cpp
@@ -82,10 +82,10 @@ else
 
 size_type argmedian(double* x, size_type n, size_type* ws, RNG* rng)
 {
-int delete_flag=FALSE;
+int delete_flag=false;
 if (!ws) {
    ws = new size_type [n];
-   delete_flag=TRUE;
+   delete_flag=false;
    }
 for (size_type i=0; i<n; i++)
   ws[i] = i;

--- a/src/pebbl/utilib-old/pvector.h
+++ b/src/pebbl/utilib-old/pvector.h
@@ -228,7 +228,7 @@ private:
    static int stream_cast(const Any& from, Any& to)
    {
       to.set<TO>() << from.template expose<FROM>();
-      return OK;
+      return 0;
    }
 
    static bool register_aux_functions()

--- a/src/pebbl/utilib/Basic2DArray.h
+++ b/src/pebbl/utilib/Basic2DArray.h
@@ -383,7 +383,7 @@ int Basic2DArray<T>::resize(const size_type nrows, const size_type ncols)
 // Maybe we get lucky.
 //
 if ((ncols == a->Ncols) && (nrows == a->Nrows))
-   return OK;
+   return 0;
 
 //
 // Need to completely replace old data.
@@ -417,7 +417,7 @@ if ((ncols != a->Ncols) && (nrows != a->Nrows)) {
    a->own_data = DataOwned;
    a->Nrows = nrows;
    a->Ncols = ncols;
-   return OK;
+   return 0;
    }
 
 //
@@ -477,7 +477,7 @@ if (ncols != a->Ncols) {
    a->Ncols = ncols;
    }
 
-return OK;
+return 0;
 }
 
 

--- a/src/pebbl/utilib/BasicArray.h
+++ b/src/pebbl/utilib/BasicArray.h
@@ -543,7 +543,7 @@ private:
    static int stream_cast(const Any& from, Any& to)
    {
       to.set<TO>() << from.template expose<FROM>();
-      return OK;
+      return 0;
    }
 
 #endif

--- a/src/pebbl/utilib/BitArray.cpp
+++ b/src/pebbl/utilib/BitArray.cpp
@@ -33,7 +33,7 @@ int cast_bitArray_to_vector(const Any& from, Any& to)
    size_t i = src.size();
    ans.resize(i);
    for( ; i > 0; --i, ans[i] = src(i) );
-   return OK;
+   return 0;
 }
 
 int cast_vector_to_bitArray(const Any& from, Any& to)
@@ -44,7 +44,7 @@ int cast_vector_to_bitArray(const Any& from, Any& to)
    size_t i = src.size();
    ans.resize(i);
    for( ; i > 0; --i, src[i] ? ans.set(i) : ans.reset(i) );
-   return OK;
+   return 0;
 }
 
 } // namespace utilib::(local)

--- a/src/pebbl/utilib/BitArrayBase.h
+++ b/src/pebbl/utilib/BitArrayBase.h
@@ -465,7 +465,7 @@ int BitArrayBase<k,T,P>::read(std::istream& s)
       put(i,(T) translate_from_char(c));
     }
 
-  return OK ;
+  return 0;
 }
 
 
@@ -509,7 +509,7 @@ int BitArrayBase<k,T,P>::write(std::ostream& output) const
 	  output << translate_to_char(temp & data_mask);
 	}
     }
-  return OK ;
+  return 0;
 }
 
 
@@ -533,7 +533,7 @@ int BitArrayBase<k,T,P>::write(PackBuffer& output) const
     }
   else
     output << (size_t) 0;
-  return OK ;
+  return 0;
 }
 
 
@@ -544,7 +544,7 @@ int BitArrayBase<k,T,P>::read(UnPackBuffer& input)
   input >> read_len;
   base_t::resize(read_len, 0);    /* The zero means don't set new contents */
   input.unpack(Data, alloc_size(read_len));
-  return OK ;
+  return 0;
 }
 
 

--- a/src/pebbl/utilib/CharString.cpp
+++ b/src/pebbl/utilib/CharString.cpp
@@ -209,7 +209,7 @@ long int aslong(const CharString& str, int& status)
   if (str.data() && str.data()[0]){
     ans = strtol(str.data(), &endptr, 10);
     if (*endptr == NULL) {
-       status = OK;
+       status = 0;
        }
     else if ((endptr[0] == 'e') || (endptr[0] == 'E')) {
        endptr++;
@@ -219,7 +219,7 @@ long int aslong(const CharString& str, int& status)
        if (*endptr == NULL) {
 	  for (long int i=0; i<tmp; i++)
 	    ans *= 10;
-          status = OK;
+          status = 0;
           }
        }
     }
@@ -242,7 +242,7 @@ long int aslong(const CharString& str, int& status)
     i++;
     }
   if ((i == str.size()) || !str[i]) {
-     if (!j) status = OK;
+     if (!j) status = 0;
      return ans;
      }
   if (str[i] != 'e') return ans;	// AN ERROR
@@ -254,7 +254,7 @@ long int aslong(const CharString& str, int& status)
   if (expn < 0) return ans;		// AN ERROR
   for (int k=0; k<expn; k++)
     ans = ans*10;
-  status = OK;
+  status = 0;
   return ans;
 #endif
 }
@@ -266,7 +266,7 @@ double asdouble(const CharString& str, int& status)
   char* ptr = NULL;
   ans = strtod(str.data(),&ptr);
   if ((ptr == NULL) || (ptr[0] == '\000'))
-    status = OK;
+    status = 0;
   else
     status = ERR;
   return ans;

--- a/src/pebbl/utilib/CharString.cpp
+++ b/src/pebbl/utilib/CharString.cpp
@@ -204,7 +204,7 @@ long int aslong(const CharString& str, int& status)
   long int ans=0;
   char *endptr = str.data();   // first invalid character
 
-  status = ERR;
+  status = PEBBL_ERR;
 
   if (str.data() && str.data()[0]){
     ans = strtol(str.data(), &endptr, 10);
@@ -228,7 +228,7 @@ long int aslong(const CharString& str, int& status)
 #else
   // This doesn't recognize ints beginning with '-'
   long int ans=0;
-  status = ERR;
+  status = PEBBL_ERR;
   size_type i=0;
   int j=0;
   while ((i < str.size()) && str[i] && isspace(str[i])) i++;
@@ -268,7 +268,7 @@ double asdouble(const CharString& str, int& status)
   if ((ptr == NULL) || (ptr[0] == '\000'))
     status = 0;
   else
-    status = ERR;
+    status = PEBBL_ERR;
   return ans;
 }
 

--- a/src/pebbl/utilib/Ereal.h
+++ b/src/pebbl/utilib/Ereal.h
@@ -1655,14 +1655,14 @@ private:
    static int assign_cast(const Any& from, Any& to)
    {
       to.set<TO>() = from.template expose<FROM>();
-      return OK;
+      return 0;
    }
 
    template<typename FROM, typename TO>
    static int stream_cast(const Any& from, Any& to)
    {
       to.set<std::vector<TO> >() << from.template expose<std::vector<FROM> >();
-      return OK;
+      return 0;
    }
 
    static bool register_aux_functions()

--- a/src/pebbl/utilib/NumArray.h
+++ b/src/pebbl/utilib/NumArray.h
@@ -187,7 +187,7 @@ private:
    static int stream_cast(const Any& from, Any& to)
    {
       to.set<TO>() << from.template expose<FROM>();
-      return OK;
+      return 0;
    }
 
    static bool register_aux_functions()

--- a/src/pebbl/utilib/Simple2DArray.h
+++ b/src/pebbl/utilib/Simple2DArray.h
@@ -187,7 +187,7 @@ if (a->Data) {
      for (size_type j=0; j<a->Ncols; j++)
        os << a->Data[i][j];
    }
-return OK;
+return 0;
 }
 
 
@@ -202,7 +202,7 @@ if (a->Data) {
      os << std::endl;
      }
    }
-return OK;
+return 0;
 }
 
 
@@ -217,7 +217,7 @@ for (size_type i=0; i<a->Nrows; i++)
   for (size_type j=0; j<a->Ncols; j++)
     is >> a->Data[i][j];
 
-return OK;
+return 0;
 }
 
 
@@ -227,7 +227,7 @@ int Simple2DArray<T>::read(std::istream& /*is*/)
 {
 //Basic2DArray<T>::free();
 
-return OK;
+return 0;
 }
 
 } // namespace utilib

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -84,9 +84,9 @@ enum { ERR = -999 };
  *
  * Value used to indicate that an operation worked.
  */
-#ifndef OK
-#define OK		0
-#endif
+//#ifndef OK
+//#define OK		0
+//#endif
 
 /**
  * \def TRUE

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -71,32 +71,22 @@ enum { PEBBL_ERR = -999 };
 #if defined(__cplusplus)
 } // namespace end
 #endif
-
-/**
- * \def OK
- *
- * Value used to indicate that an operation worked.
- */
-//#ifndef OK
-//#define OK		0
-//#endif
-
 /**
  * \def NULL
  *
  * Defines the value of empty pointers.
  */
-//#ifdef NULL
-//#undef NULL		/* Always override the definition of NULL */
-//#endif
-//#define NULL		0
+#ifdef NULL
+#undef NULL		/* Always override the definition of NULL */
+#endif
+#define NULL		0
 
 /**
  * \def PAUSE
  *
  * A macro that waits for the user to hit a key.
  */
-#define PAUSE()	fflush(stdout); while(fgetc(stdin) == EOF);
+#define PAUSE()	fflush(stdout); while(fgetc(stdin) == -1);
 
 /**
  * \def _(args)

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -73,7 +73,7 @@ enum {BUF_SIZE=256 };
  *
  * The default value of error values.
  */
-enum { ERR = -999 };
+enum { PEBBL_ERR = -999 };
 
 #if defined(__cplusplus)
 } // namespace end
@@ -93,10 +93,10 @@ enum { ERR = -999 };
  *
  * Defines the value of empty pointers.
  */
-#ifdef NULL
-#undef NULL		/* Always override the definition of NULL */
-#endif
-#define NULL		0
+//#ifdef NULL
+//#undef NULL		/* Always override the definition of NULL */
+//#endif
+//#define NULL		0
 
 /**
  * \def PAUSE
@@ -117,7 +117,8 @@ enum { ERR = -999 };
 #endif
 
 
-#ifdef DEBUG			/* Debug defines to see if conflicts exist */
+//#ifdef DEBUG 
+/* Debug defines to see if conflicts exist */
 //#define TRUE	1
 //#define FALSE	0
 //#define OK	0
@@ -128,7 +129,7 @@ enum { ERR = -999 };
 //#define NULL	0
 //#define EOF	(-1)
 //#define ERR	-999
-#endif
+//#endif
 
 
 #if !defined(UTILIB_HAVE_STD) && !defined(__cplusplus)

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -62,13 +62,6 @@ enum OrderSense
 #endif
 
 /**
- * \def BUF_SIZE
- *
- * A default size for buffers
- */
-enum {BUF_SIZE=256 };
-
-/**
  * \def ERR
  *
  * The default value of error values.
@@ -78,25 +71,6 @@ enum { ERR = -999 };
 #if defined(__cplusplus)
 } // namespace end
 #endif
-
-/**
- * \def OK
- *
- * Value used to indicate that an operation worked.
- */
-//#ifndef OK
-//#define OK		0
-//#endif
-
-/**
- * \def NULL
- *
- * Defines the value of empty pointers.
- */
-#ifdef NULL
-#undef NULL		/* Always override the definition of NULL */
-#endif
-#define NULL		0
 
 /**
  * \def PAUSE
@@ -115,21 +89,6 @@ enum { ERR = -999 };
 #else
 #define _(args) ()
 #endif
-
-
-#ifdef DEBUG			/* Debug defines to see if conflicts exist */
-//#define TRUE	1
-//#define FALSE	0
-//#define OK	0
-//#define ON	1
-//#define OFF	0
-//#define YES	1
-//#define NO	0
-//#define NULL	0
-//#define EOF	(-1)
-//#define ERR	-999
-#endif
-
 
 #if !defined(UTILIB_HAVE_STD) && !defined(__cplusplus)
 /**

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -181,16 +181,16 @@ enum { ERR = -999 };
 
 
 #ifdef DEBUG			/* Debug defines to see if conflicts exist */
-#define TRUE	1
-#define FALSE	0
-#define OK	0
-#define ON	1
-#define OFF	0
-#define YES	1
-#define NO	0
-#define NULL	0
-#define EOF	(-1)
-#define ERR	-999
+//#define TRUE	1
+//#define FALSE	0
+//#define OK	0
+//#define ON	1
+//#define OFF	0
+//#define YES	1
+//#define NO	0
+//#define NULL	0
+//#define EOF	(-1)
+//#define ERR	-999
 #endif
 
 

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -89,60 +89,6 @@ enum { ERR = -999 };
 #endif
 
 /**
- * \def TRUE
- *
- * The boolean value for true.
- */
-#ifndef TRUE
-#define TRUE		1
-#endif
-
-/**
- * \def FALSE
- *
- * The boolean value for false.
- */
-#ifndef FALSE
-#define FALSE		0
-#endif
-
-/**
- * \def ON
- *
- * Used to incidate the on state.
- */
-#ifndef ON
-#define ON		1
-#endif
-
-/**
- * \def OFF
- *
- * Used to incidate the off state.
- */
-#ifndef OFF
-#define OFF		0
-#endif
-
-/**
- * \def YES
- *
- * Used to incidate a yes response.
- */
-#ifndef YES
-#define YES		1
-#endif
-
-/**
- * \def NO
- *
- * Used to incidate a no response.
- */
-#ifndef NO
-#define NO		0
-#endif
-
-/**
  * \def NULL
  *
  * Defines the value of empty pointers.
@@ -151,15 +97,6 @@ enum { ERR = -999 };
 #undef NULL		/* Always override the definition of NULL */
 #endif
 #define NULL		0
-
-/**
- * \def EOF
- *
- * The end-of-file value.
- */
-#ifndef EOF
-#define EOF		(-1)
-#endif
 
 /**
  * \def PAUSE

--- a/src/pebbl/utilib/_generic.h
+++ b/src/pebbl/utilib/_generic.h
@@ -72,24 +72,6 @@ enum { PEBBL_ERR = -999 };
 } // namespace end
 #endif
 
-/**
- * \def OK
- *
- * Value used to indicate that an operation worked.
- */
-//#ifndef OK
-//#define OK		0
-//#endif
-
-/**
- * \def NULL
- *
- * Defines the value of empty pointers.
- */
-//#ifdef NULL
-//#undef NULL		/* Always override the definition of NULL */
-//#endif
-//#define NULL		0
 
 /**
  * \def PAUSE
@@ -108,21 +90,6 @@ enum { PEBBL_ERR = -999 };
 #else
 #define _(args) ()
 #endif
-
-
-//#ifdef DEBUG 
-/* Debug defines to see if conflicts exist */
-//#define TRUE	1
-//#define FALSE	0
-//#define OK	0
-//#define ON	1
-//#define OFF	0
-//#define YES	1
-//#define NO	0
-//#define NULL	0
-//#define EOF	(-1)
-//#define ERR	-999
-//#endif
 
 
 #if !defined(UTILIB_HAVE_STD) && !defined(__cplusplus)

--- a/src/pebbl/utilib/math_matrix.h
+++ b/src/pebbl/utilib/math_matrix.h
@@ -38,7 +38,7 @@ for (size_type j=0; j<matrix.nrows(); j++)
   for (size_type i=0; i<matrix.ncols(); i++)
     temp[i] += matrix[j][i];
 
-if (stats_flag == TRUE)
+if (stats_flag == true)
      temp /= ((double) (matrix.nrows() - 1));
 else
      temp /= ((double) matrix.nrows());
@@ -49,7 +49,7 @@ return( temp );
 
 /// Compute the variances of the rows of a matrix.
 template <class T>
-DoubleVector var(const Basic2DArray<T>& mat, const int sampleflag=TRUE)
+DoubleVector var(const Basic2DArray<T>& mat, const int sampleflag=true)
 {
 DoubleVector array_mean;
 return( var(mat, array_mean, sampleflag) );
@@ -59,7 +59,7 @@ return( var(mat, array_mean, sampleflag) );
 /// Compute the variances of the rows of a 2D array, given the means.
 template <class T>
 DoubleVector var(const Basic2DArray<T>& mat, BasicArray<double>& array_mean, 
-							const int sampleflag=TRUE)
+							const int sampleflag=true)
 {
 DoubleVector ans(mat.ncols());
 array_mean &= mean(mat);
@@ -69,7 +69,7 @@ for (size_type i=0; i<mat.nrows(); i++)
   for (size_type j=0; j<ans.size(); j++)
     ans[j] += ((mat[i][j] - array_mean[j]) * (mat[i][j] - array_mean[j]));
 
-if ((sampleflag == FALSE) || (mat.nrows() == 1))
+if ((sampleflag == false) || (mat.nrows() == 1))
    ans /= (double) (mat.nrows());
 else
    ans /= (double)(mat.nrows()-1);

--- a/src/pebbl/utilib/mpiUtil.cpp
+++ b/src/pebbl/utilib/mpiUtil.cpp
@@ -80,9 +80,9 @@ void uMPI::init(MPI_Comm comm_)
   // fall back on ioProc=0 default.
   int flag, result;
   int* mpiIOP;
-  errorCode = MPI_Attr_get(MPI_COMM_WORLD,MPI_IO,&mpiIOP,&flag);
+  errorCode = MPI_Comm_get_attr(MPI_COMM_WORLD,MPI_IO,&mpiIOP,&flag);
   if (errorCode || !flag)
-     ucerr << "MPI_Attr_get(MPI_IO) failed, code " << errorCode << endl;
+     ucerr << "MPI_Comm_get_attr(MPI_IO) failed, code " << errorCode << endl;
   MPI_Comm_compare(comm, MPI_COMM_WORLD, &result);
   if (result==MPI_IDENT || result==MPI_CONGRUENT) // no mapping of MPI_IO reqd.
     ioProc = *mpiIOP;
@@ -121,10 +121,10 @@ void uMPI::done()
 
 int uMPI::sizeOf(MPI_Datatype t)
 {
-  MPI_Aint extent;
-  errorCode = MPI_Type_extent(t,&extent);
+  MPI_Aint extent, lb;
+  errorCode = MPI_Type_get_extent(t,&lb,&extent);
   if (errorCode)
-     ucerr << "MPI_Type_extent failed, code " << errorCode << endl;
+     ucerr << "MPI_Type_get_extent failed, code " << errorCode << endl;
   return extent;
 }
 

--- a/src/pebbl/utilib/mpiUtil.h
+++ b/src/pebbl/utilib/mpiUtil.h
@@ -420,7 +420,7 @@ public:
 class uMPI 
 {
 public:
-  static int running() { return FALSE; };
+  static int running() { return false; };
 
   static int rank;
 };


### PR DESCRIPTION
No changes were made to the utilib tests (packages/utilib/test/studies). Unknown if these are needed.